### PR TITLE
build: fully leverage ESM for `pages` script and `magidoc` config

### DIFF
--- a/docs/magidoc.mjs
+++ b/docs/magidoc.mjs
@@ -1,9 +1,6 @@
-import path, { dirname } from 'path'
-import { fileURLToPath } from 'url'
+import { fileURLToPath } from 'node:url'
 
-const pages = (await import(`./pages.mjs?id=${Math.random()}`)).default
-
-const __dirname = dirname(fileURLToPath(import.meta.url))
+const { pages } = await import(`./pages.mjs?id=${Math.random()}`)
 
 /**
  * @type {import("@magidoc/cli").MagidocConfiguration}
@@ -13,9 +10,11 @@ const config = {
     type: 'none',
   },
   website: {
-    template: path.join(__dirname, '../packages/starters/carbon-multi-page'),
-    output: path.join(__dirname, 'build'),
-    staticAssets: path.join(__dirname, 'assets'),
+    template: fileURLToPath(
+      new URL('../packages/starters/carbon-multi-page', import.meta.url),
+    ),
+    output: fileURLToPath(new URL('./build', import.meta.url)),
+    staticAssets: fileURLToPath(new URL('./assets', import.meta.url)),
     options: {
       appTitle: 'Magidoc',
       appFavicon:
@@ -67,8 +66,8 @@ const config = {
   },
   dev: {
     watch: [
-      path.join(__dirname, './pages'),
-      path.join(__dirname, './pages.mjs'),
+      fileURLToPath(new URL('./pages', import.meta.url)),
+      fileURLToPath(new URL('./pages.mjs', import.meta.url)),
     ],
   },
 }

--- a/docs/pages.mjs
+++ b/docs/pages.mjs
@@ -3,9 +3,8 @@ import { join } from 'node:path'
 import { fileURLToPath } from 'node:url'
 
 /**
- * Scans the directory for files and collects them
- * @param {import("node:fs").PathLike} dir The directory to scan the files from
- * @returns {Promise<Array<{ dir: boolean; name: string; path: string; }>>} The files in the directory
+ * @param {import("node:fs").PathLike} dir
+ * @returns {Promise<Array<{ dir: boolean; name: string; path: string; }>>}
  */
 async function getFiles(dir) {
   /**
@@ -32,9 +31,8 @@ async function getFiles(dir) {
 }
 
 /**
- * Get all items as page objects
- * @param {{ dir: boolean; name: string; path: string; }} item The item to parse
- * @returns {{ title: string; content: any }} Returns the item as a Page
+ * @param {{ dir: boolean; name: string; path: string; }} item
+ * @returns {{ title: string; content: any }}
  */
 async function asPage(item) {
   // 01.Introduction -> Introduction

--- a/docs/pages.mjs
+++ b/docs/pages.mjs
@@ -1,47 +1,65 @@
-import path, { dirname } from "path";
-import { fileURLToPath } from "url";
-import fs from "fs";
+import { readdir, readFile, stat } from 'node:fs/promises'
+import { join } from 'node:path'
+import { fileURLToPath } from 'node:url'
 
-function getFiles(dir) {
-  return fs.readdirSync(dir).flatMap((item) => {
-    const currentPath = path.join(dir, item);
-    if (fs.statSync(currentPath).isDirectory()) {
-      return {
-        dir: true,
-        name: item,
-        path: currentPath,
-      };
-    }
+/**
+ * Scans the directory for files and collects them
+ * @param {import("node:fs").PathLike} dir The directory to scan the files from
+ * @returns {Promise<Array<{ dir: boolean; name: string; path: string; }>>} The files in the directory
+ */
+async function getFiles(dir) {
+  /**
+   * @type Array<{ dir: boolean; name: string; path: string; }>
+   */
+  const result = []
+  const dirAsPathString = dir instanceof URL ? fileURLToPath(dir) : dir
 
-    return {
-      dir: false,
+  const dirContents = await readdir(dir)
+
+  for (const item of dirContents) {
+    const currentPath = join(dirAsPathString, item)
+
+    const currentPathStat = await stat(currentPath)
+
+    result.push({
+      dir: currentPathStat.isDirectory(),
       name: item,
       path: currentPath,
-    };
-  });
+    })
+  }
+
+  return result
 }
 
-function asPage(item) {
+/**
+ * Get all items as page objects
+ * @param {{ dir: boolean; name: string; path: string; }} item The item to parse
+ * @returns {{ title: string; content: any }} Returns the item as a Page
+ */
+async function asPage(item) {
   // 01.Introduction -> Introduction
   // 01.Welcome.md -> Welcome
-  const title = item.name.split(".")[1];
+  const title = item.name.split('.')[1]
 
   if (item.dir) {
+    const filesInDirectory = await getFiles(item.path)
+
     return {
       title: title,
-      content: getFiles(item.path).map((item) => asPage(item)),
-    };
+      content: await Promise.all(filesInDirectory.map((item) => asPage(item))),
+    }
   }
 
   return {
     title: title,
-    content: fs.readFileSync(item.path).toString(),
-  };
+    content: await readFile(item.path, { encoding: 'utf-8' }),
+  }
 }
 
-const __dirname = dirname(fileURLToPath(import.meta.url));
-const targetPagesPath = path.join(__dirname, "pages");
+const pagesDirectory = new URL('./pages', import.meta.url)
 
-const pages = getFiles(targetPagesPath).map((item) => asPage(item));
+const filesInPagesDirectory = await getFiles(pagesDirectory)
 
-export default pages;
+export const pages = await Promise.all(
+  filesInPagesDirectory.map((item) => asPage(item)),
+)


### PR DESCRIPTION
The `magidoc.mjs` and `pages.mjs` are ESM files, so lets get everything out of ESM that we can instead of doing a half/half CJS/ESM setup.

- Leverage top level await in `pages.mjs`
  - This goes hand-in-hand with the swap to the newer `fs/promises` as opposed to the old synchronous `fs` from Node.
- Use a named export of `pages` to remove braces and a `.default` in `magidoc.mjs`
- Use named imports in `pages.mjs`
- Specify encoding in `readFile` so no `.toString()` is required
- Add more type information to `pages.mjs` for some basic TypeScript language service support
- Use file path URLs for everything in `magidoc.mjs`, instead of monkeypatching `__dirname` back in.