### PR TITLE
Clarified Github Pages deployment

### DIFF
--- a/docs/pages/02.Cli/01.Magidoc Configuration.md
+++ b/docs/pages/02.Cli/01.Magidoc Configuration.md
@@ -172,6 +172,7 @@ export default {
       /**
        * Your application logo, which can either be
        * an absolute URL or a relative URL pointing to a static asset.
+       * If your `siteRoot` is set and you use a relative URL, include the `siteRoot` in the path
        *
        * @default (magidoc logo)
        */

--- a/docs/pages/05.Deployment/01.GitHub Pages.md
+++ b/docs/pages/05.Deployment/01.GitHub Pages.md
@@ -18,7 +18,7 @@ export default {
     staticAssets: path.join(__dirname, 'assets'),
     options: {
       // You need to specify the base path of your github pages root
-      // Example: `/magidoc-org/magidoc`
+      // Example: `/magidoc`
       siteRoot: '/<user>/<repo>',
     },
     // ...

--- a/docs/pages/05.Deployment/01.GitHub Pages.md
+++ b/docs/pages/05.Deployment/01.GitHub Pages.md
@@ -40,5 +40,5 @@ magidoc.mjs
 
 If you are deploying this from a private repo in an organization, omit the `siteRoot` property altogether because it will be a URL along the lines of `https://random-string-hash.pages.github.io/queries/my-query`. 
 
-If it it a public repo in an organization then it becomes `https://<organization>.github.io/my-repo/` and your `siteRoot` should be just be `/<repo>`.
+If it is a public repo in an organization then it becomes `https://<organization>.github.io/my-repo/` and your `siteRoot` should be just be `/<repo>`.
 

--- a/docs/pages/05.Deployment/01.GitHub Pages.md
+++ b/docs/pages/05.Deployment/01.GitHub Pages.md
@@ -19,7 +19,7 @@ export default {
     options: {
       // You need to specify the base path of your github pages root
       // Example: `/magidoc-org/magidoc`
-      siteRoot: '/<user|organization>/<repo>',
+      siteRoot: '/<user>/<repo>',
     },
     // ...
   },
@@ -27,10 +27,18 @@ export default {
 ```
 
 ## Static assets
-Since GitHub tries to use Jekyll by default to render your website, we need to disable Jekyll. You can do this by creating an empty file named `.nojekyll` inside the `assets` folder. 
+
+Since GitHub tries to use Jekyll by default to render your website, we need to disable Jekyll. You can do this by creating an empty file named `.nojekyll` inside the `assets` folder.
 
 ```
 assets
 └── .nojekyll
 magidoc.mjs
 ```
+
+## siteRoot
+
+If you are deploying this from a private repo in an organization, omit the `siteRoot` property altogether because it will be a URL along the lines of `https://random-string-hash.pages.github.io/queries/my-query`. 
+
+If it it a public repo in an organization then it becomes `https://<organization>.github.io/my-repo/` and your `siteRoot` should be just be `/<repo>`.
+


### PR DESCRIPTION
I've published my generated documentation on Github Pages (first as a private repo, then as a public one) and neither times the OOTB recommended configuration was correct. 