### PR TITLE
Feature/support image base path

### DIFF
--- a/packages/plugins/svelte-marked/src/lib/markdown/components/MarkdownImage.svelte
+++ b/packages/plugins/svelte-marked/src/lib/markdown/components/MarkdownImage.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import type { Tokens } from 'marked'
   import type { MarkdownOptions, Renderers } from '../markedConfiguration'
+  import { isRelative, joinUrlPaths } from '$lib/utils/url'
 
   export let token: Tokens.Image
   export const options: MarkdownOptions = undefined
@@ -8,7 +9,9 @@
 </script>
 
 <img
-  src={token.href}
+  src={isRelative(token.href)
+    ? joinUrlPaths(options.baseUrl, token.href)
+    : token.href}
   title={token.title}
   alt={token.text}
   class="markdown-image"

--- a/packages/plugins/svelte-marked/src/lib/markdown/components/MarkdownImage.svelte
+++ b/packages/plugins/svelte-marked/src/lib/markdown/components/MarkdownImage.svelte
@@ -4,7 +4,7 @@
   import { isRelative, joinUrlPaths } from '$lib/utils/url'
 
   export let token: Tokens.Image
-  export const options: MarkdownOptions = undefined
+  export let options: MarkdownOptions
   export const renderers: Renderers = undefined
 </script>
 

--- a/packages/starters/carbon-multi-page/src/lib/variables.ts
+++ b/packages/starters/carbon-multi-page/src/lib/variables.ts
@@ -12,6 +12,5 @@ export function getOrDefault<T>(target: Variable<T>, def: T) {
 
 export function getSiteRoot() {
   // Using $app/paths sometimes return an empty string for an unknown reason, which causes the build to fail.
-  //
   return getOrDefault(templates.SITE_ROOT, base)
 }


### PR DESCRIPTION
Breaking: Use site root in images base path for markdown images