### PR TITLE
chore(cli): add support for bun package manager

### DIFF
--- a/packages/cli/src/node/packageManager.ts
+++ b/packages/cli/src/node/packageManager.ts
@@ -3,7 +3,7 @@ import { promisify } from 'util'
 
 const execPromise = promisify(exec)
 
-export const PACKAGE_MANAGER_TYPES = ['pnpm', 'yarn', 'npm'] as const
+export const PACKAGE_MANAGER_TYPES = ['pnpm', 'bun', 'yarn', 'npm'] as const
 
 export type PackageManagerType = (typeof PACKAGE_MANAGER_TYPES)[number]
 
@@ -30,6 +30,10 @@ export async function selectPackageManager(): Promise<PackageManager> {
     return createPnpm()
   }
 
+  if (await isPackageManagerAvailable('bun')) {
+    return createRunner({ type: 'bun' })
+  }
+
   if (await isPackageManagerAvailable('npm')) {
     return createNpm()
   }
@@ -45,6 +49,7 @@ export async function selectPackageManager(): Promise<PackageManager> {
 
 export function getPackageManager(type: PackageManagerType) {
   if (type === 'pnpm') return createPnpm()
+  if (type === 'bun') return createBun()
   if (type === 'yarn') return createYarn()
   if (type === 'npm') return createNpm()
   throw new Error(`Unknown package manager ${type as string}.`)
@@ -60,6 +65,10 @@ function createYarn(): PackageManager {
 
 function createNpm(): PackageManager {
   return createRunner({ type: 'npm', installArgs: ['--legacy-peer-deps'] })
+}
+
+function createBun(): PackageManager {
+  return createRunner({ type: 'bun' })
 }
 
 function createRunner({

--- a/packages/starters/carbon-multi-page/src/routes/+layout.svelte
+++ b/packages/starters/carbon-multi-page/src/routes/+layout.svelte
@@ -35,7 +35,7 @@ setupMarkedExtensions()
 // Alllows custom commands to highlight in shell syntax
 Prism.languages.insertBefore('shell', 'function', {
   keyword: {
-    pattern: /(^\s*)(?:magidoc|pnpm|npm|yarn)(?=\s)/m,
+    pattern: /(^\s*)(?:magidoc|pnpm|npm|yarn|bun)(?=\s)/m,
     lookbehind: true,
   },
 })


### PR DESCRIPTION
Since yarn, npm and pnpm are already supported, I see no reason not to support bun.
I tested it via bun patch package and everything worked flawlessly. The `magidoc generate` was about twice as fast as with pnpm.

We use a bun only Dockerfile where there is no option to add node / npm just to build the docs.
