### PR TITLE
Fix search input being broken

### DIFF
--- a/packages/starters/carbon-multi-page/src/lib/layout/AppHeader.svelte
+++ b/packages/starters/carbon-multi-page/src/lib/layout/AppHeader.svelte
@@ -53,12 +53,13 @@ onDestroy(() => {
         on:click={() => (searchOpen = true)}
       />
     {:else}
-      <div class="search-bar-wrapper">
+      <!-- svelte-ignore a11y-click-events-have-key-events -->
+      <!-- svelte-ignore a11y-no-static-element-interactions -->
+      <div class="search-bar-wrapper" on:click={() => (searchOpen = true)}>
         <SearchBar
           placeholder={`Search ${appTitle}... (${isMac ? '⌘' : 'Ctrl'}+K)`}
           autocomplete={'off'}
           size="sm"
-          on:focus={() => (searchOpen = true)}
         />
       </div>
     {/if}

--- a/packages/starters/carbon-multi-page/src/lib/search.ts
+++ b/packages/starters/carbon-multi-page/src/lib/search.ts
@@ -80,33 +80,46 @@ const schemaSearch: Fuse<FuseGraphQLSearchResult> = indexSchema(schema, {
 })
 
 export function search(query: string): ReadonlyArray<MagidocSearchResult> {
-  const pagesResult: ReadonlyArray<MagidocSearchResult> = pagesSearch.search(query).map((result) => ({
-    type: 'markdown',
-    score: result.score || 0,
-    result: result.item,
-    matches: (result.matches || []).map((match) => ({
-      value: match.value || '',
-      location: match.key || '',
-      indices: collapseIndexes(match.indices),
-    })),
-  }))
+  const normalizedQuery = query.trim()
+  if (!normalizedQuery) return []
 
-  let schemaResult: ReadonlyArray<MagidocSearchResult> = []
-
-  if (!isModelEmpty()) {
-    schemaResult = schemaSearch.search(query).map((result) => ({
-      type: 'graphql',
+  const pagesResult: ReadonlyArray<MagidocSearchResult> = pagesSearch
+    .search(normalizedQuery)
+    .map((result) => ({
+      type: 'markdown' as const,
       score: result.score || 0,
       result: result.item,
       matches: (result.matches || []).map((match) => ({
         value: match.value || '',
         location: match.key || '',
-        indices: match.indices,
+        indices: collapseIndexes(match.indices),
       })),
     }))
+    .filter(hasMatches)
+
+  let schemaResult: ReadonlyArray<MagidocSearchResult> = []
+
+  if (!isModelEmpty()) {
+    schemaResult = schemaSearch
+      .search(normalizedQuery)
+      .map((result) => ({
+        type: 'graphql' as const,
+        score: result.score || 0,
+        result: result.item,
+        matches: (result.matches || []).map((match) => ({
+          value: match.value || '',
+          location: match.key || '',
+          indices: match.indices,
+        })),
+      }))
+      .filter(hasMatches)
   }
 
   return mergeResults(pagesResult, schemaResult)
+}
+
+function hasMatches(result: MagidocSearchResult): boolean {
+  return result.matches.length > 0
 }
 
 function mergeResults(

--- a/packages/starters/carbon-multi-page/tests/search.test.mjs
+++ b/packages/starters/carbon-multi-page/tests/search.test.mjs
@@ -1,6 +1,6 @@
 import assert from 'node:assert/strict'
-import { after, test } from 'node:test'
 import path from 'node:path'
+import { after, test } from 'node:test'
 import { fileURLToPath } from 'node:url'
 import { createServer } from 'vite'
 
@@ -78,12 +78,7 @@ test('search returns displayable markdown matches for a complete query', () => {
   assert.ok(Array.isArray(results[0].matches[0].indices))
 })
 
-test('search keeps markdown results renderable before the user enters a query', () => {
-  const results = search('')
-
-  assert.doesNotThrow(() => {
-    for (const result of results) {
-      result.matches[0].indices
-    }
-  })
+test('search returns no results before the user enters a query', () => {
+  assert.deepEqual(search(''), [])
+  assert.deepEqual(search('   '), [])
 })

--- a/packages/starters/carbon-multi-page/tests/search.test.mjs
+++ b/packages/starters/carbon-multi-page/tests/search.test.mjs
@@ -1,0 +1,89 @@
+import assert from 'node:assert/strict'
+import { after, test } from 'node:test'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { createServer } from 'vite'
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..')
+const virtualPrefix = '\0magidoc-search-test:'
+
+const modules = {
+  [`${virtualPrefix}graphql`]: `
+    export function index() {
+      return { search: () => [] }
+    }
+  `,
+  [`${virtualPrefix}markdown`]: `
+    export function setupMarkedExtensions() {}
+  `,
+  [`${virtualPrefix}model`]: `
+    export const schema = {}
+    export function isModelEmpty() {
+      return true
+    }
+  `,
+  [`${virtualPrefix}pages`]: `
+    export const pages = [{
+      type: 'page',
+      title: 'Welcome',
+      href: '/welcome',
+      content: ['# Welcome', '', 'We test search while typing.'].join('\\n'),
+    }]
+  `,
+}
+
+const server = await createServer({
+  root,
+  configFile: false,
+  logLevel: 'silent',
+  appType: 'custom',
+  oxc: {
+    tsconfig: false,
+  },
+  resolve: {
+    alias: {
+      '@magidoc/plugin-fuse-markdown': path.resolve(root, '../../plugins/fuse-markdown/src/index.ts'),
+    },
+  },
+  server: {
+    middlewareMode: true,
+  },
+  plugins: [
+    {
+      name: 'magidoc-search-test-stubs',
+      enforce: 'pre',
+      resolveId(id, importer) {
+        if (id === '@magidoc/plugin-fuse-graphql') return `${virtualPrefix}graphql`
+        if (!importer?.endsWith('/src/lib/search.ts')) return undefined
+        if (id === './markdown') return `${virtualPrefix}markdown`
+        if (id === './model') return `${virtualPrefix}model`
+        if (id === './pages') return `${virtualPrefix}pages`
+        return undefined
+      },
+      load(id) {
+        return modules[id]
+      },
+    },
+  ],
+})
+
+after(() => server.close())
+
+const { search } = await server.ssrLoadModule('/src/lib/search.ts')
+
+test('search returns displayable markdown matches for a complete query', () => {
+  const results = search('welcome')
+
+  assert.equal(results[0].type, 'markdown')
+  assert.ok(Array.isArray(results[0].matches[0].indices))
+})
+
+test('search keeps markdown results renderable before the user enters a query', () => {
+  const results = search('')
+
+  assert.doesNotThrow(() => {
+    for (const result of results) {
+      result.matches[0].indices
+    }
+  })
+})


### PR DESCRIPTION
The current version of magidoc has two bugs related to search:

1. The search modal does not open at all, and instead an error is logged to the console. This happens on magidoc's own web site: https://magidoc.js.org/ <- clicking on the Search bar in top right corner and typing will not do anything other than error in JS console.

2. If that's fixed, the searching modal only shows up briefly when you click in the search bar input. You have to mouse press and hold it in order to use searh results. Either way, then you cannot click on anything in search results because it disapperas the moment you try to click it. See the video below:


https://github.com/user-attachments/assets/b56237f4-49f0-488f-ad4f-7ef189f6a4da

This PR fixes both issues. First, fixes the searching itself by preventing the crash on no results. Then, fixes the modal disappearing by switching from focus to click event.